### PR TITLE
merge pack incrementation, level progress bar changes, and updated font into homepage

### DIFF
--- a/source/homepage/index.html
+++ b/source/homepage/index.html
@@ -27,11 +27,11 @@
       <stats-container>
         <stat-display class="gems">
           <span class="stat-icon">&#9672;</span>
-          <span class="stat-value gems">0</span>
+          <span class="stat-value gems">250</span>
         </stat-display>
         <stat-display class="packs">
           <span class="stat-icon">&#10697;</span>
-          <span class="stat-value packs">0</span>
+          <span id="packsCount" class="stat-value packs">12</span>
         </stat-display>
       </stats-container>
     </div>
@@ -46,13 +46,13 @@
         <stats-container>
           <stat-display class="packs">
             <span class="stat-icon">&#10697;</span>
-            <span class="stat-value" id="currentPacks">0</span>
+            <span class="stat-value" id="currentPacks">12</span>
           </stat-display>
         </stats-container>
         <div class="progress-bar pack-bar">
           <div class="progress" id="packProgress"></div>
         </div>
-        <div class="pack-time" id="packTimeLeft">5h 32min left</div>
+        <div class="pack-time" id="packTimeLeft">Time Left Placeholder</div>
       </div>
     </div>
   </main>

--- a/source/homepage/script.js
+++ b/source/homepage/script.js
@@ -29,11 +29,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById("userLevel").textContent = `Level ${userData.userLevel}`;
 
   // ====================== 4) Level Progress Bar ======================
-  const levelBar = document.getElementById("levelProgress");
+  //const levelBar = document.getElementById("levelProgress");
   // Set width to X% (fills the bar)
-  levelBar.style.width = `${userData.levelProgress}%`;
+  //levelBar.style.width = `${userData.levelProgress}%`;
   // Display the numeric percentage inside the colored bar
-  levelBar.textContent = `${userData.levelProgress}%`;
+  //levelBar.textContent = `${userData.levelProgress}%`;
 
   // ====================== 5) Currency (Gems & Packs) ======================
   document.querySelector(".stat-value.gems").textContent = userData.gemsCount;
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // ====================== 9) Cooldown Timer & Progress Bar ======================
   const countdownText = document.getElementById("packTimeLeft");
   const cooldownBar = document.getElementById("packProgress");
-  const cooldownMinutes = 360; // 6 hours in minutes
+  const cooldownMinutes = 1; // 6 hours in minutes
   const cooldownDuration = cooldownMinutes * 60 * 1000; // 6 hours in ms
 
   // Get the start time from localStorage or set it to now if not present
@@ -119,18 +119,40 @@ document.addEventListener('DOMContentLoaded', () => {
         //Increment pack count and update local storage
         userData.packsCount += 1;
         userData.currentPacks += 1;
+
+        //update level progress
+        userData.levelProgress = (userData.currentPacks / 100) * 100;
+
+        //if pack count is greater than 100, multiply currPacks/100 by 10 to get appropriate percentage
+        if(userData.levelProgress > 100) {
+          let bigPackCount = userData.levelProgress / 100
+          userData.levelProgress = (userData.currentPacks / 100) * 10;
+        }
+
+        //set items in local storage
         localStorage.setItem('userData', JSON.stringify(userData));
       
-        //Edit page to reflect pack incrementation immmediately after timer is up
+        //get html elements to reflect pack incrementation immmediately after timer is up
         const packsCountA = document.getElementById("packsCount");
         const currentPacksA = document.getElementById("currentPacks");
+
+        //get level progress bar page 
+        const levelProgressA = document.getElementById("levelProgress");
         
+        //update page to reflect alterations - pack incrementation and level progress bar
         if(packsCountA) {
           packsCountA.textContent = userData.packsCount;
         }
 
         if(currentPacksA) {
           currentPacksA.textContent = userData.currentPacks;
+        }
+
+        if(levelProgressA) {
+          
+          levelProgressA.style.width = `${userData.levelProgress}%`;
+          // Display the numeric percentage inside the colored bar
+          levelProgressA.textContent = `${userData.levelProgress}%`;
         }
 
     }

--- a/source/homepage/script.js
+++ b/source/homepage/script.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // ====================== 6) Pack Footer: Number + Progress ======================
   document.getElementById("currentPacks").textContent = userData.packsCount;
-  const packBar = document.getElementById("packProgress");
+  //const packBar = document.getElementById("packProgress");
   // Set width for pack unlock progress
   //packBar.style.width = `${userData.packProgress}%`;
   // Display the text “75%” inside the pack progress bar
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (mainPack) {
     mainPack.addEventListener("click", () => {
       if (mainPack.classList.contains("disabled")) return;
-        startCooldown(); // Save unlock time in localStorage
+        //startCooldown(); // Save unlock time in localStorage
       // Navigate to the pack opening page
       window.location.href = "../pullpage/pack.html";
     });
@@ -125,7 +125,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         //if pack count is greater than 100, multiply currPacks/100 by 10 to get appropriate percentage
         if(userData.levelProgress > 100) {
-          let bigPackCount = userData.levelProgress / 100
           userData.levelProgress = (userData.currentPacks / 100) * 10;
         }
 

--- a/source/homepage/style.css
+++ b/source/homepage/style.css
@@ -1,8 +1,12 @@
+@import '../util/globals.css';
+@import '../components/card/cardComponent.css';
+@import url('https://fonts.googleapis.com/css2?family=Turret+Road:wght@200;300;400;500;700;800&display=swap');
 * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: Arial, sans-serif; /* Default font */
+    /*font-family: Arial, sans-serif; /* Default font */
+    font-family: var(--font-family);
   }
   
   body {


### PR DESCRIPTION
There have been updates to pack incrementation, level progress bar, and homepage font. The pack increments based on timer execution. I altered the level progress bar to reflect a percentage based on pack count using local storage. Additionally, I changed the homepage default font to match the collections page's font. 

CI/CD checks pass.