### PR TITLE
merge gem and pack count labels into homepage

### DIFF
--- a/source/homepage/index.html
+++ b/source/homepage/index.html
@@ -26,10 +26,12 @@
         <ul class="stats-list" aria-label="User Stats">
           <li>
             <span class="stat-icon gems">&#9672;</span>
+            <span class="gemCount label">Gem Count:</span>
             <span class="stat-value" id="headerGemsCount">0</span>
           </li>
           <li>
             <span class="stat-icon packs">&#10697;</span>
+            <span class="packCount label">Pack Count:</span>
             <span class="stat-value" id="headerPacksCount">0</span>
           </li>
         </ul>


### PR DESCRIPTION
Updated html to include labels for pack count and gem count in top bar.